### PR TITLE
[G2M] live flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x
-      - run: npm i
+
       - name: Create tag
         if: ${{ success() }}
         run: npx @eqworks/release tag --github -v

--- a/README.md
+++ b/README.md
@@ -6,15 +6,6 @@ Utility to scan environment variable usage in a git repository. If a serverless 
 
 ```shell
 % npx @eqworks/scan-env --help
-Options:
-      --help               Show help                                   [boolean]
-      --version            Show version number                         [boolean]
-      --serverless, --sls  Specify a serverless configuration YAML file;
-                           otherwise auto detect                        [string]
-  -s, --strict             Strict mode, exit with 1 if there are missing env
-                           vars without default values
-                                                      [boolean] [default: false]
-  -v, --verbose            Show verbose output        [boolean] [default: false]
 ```
 
 You can also install it and invoke the CLI without the scope:
@@ -22,7 +13,6 @@ You can also install it and invoke the CLI without the scope:
 ```shell
 % npm i @eqworks/scan-env # or yarn add @eqworks/scan-env
 % scan-env --help
-...
 ```
 
 ### Strict mode
@@ -55,6 +45,25 @@ PGAPPNAME:
 
 % echo $?
 1
+```
+
+### Live mode (since `v0.4.0`)
+
+For projects without any serverless configurations, test against live context exposed to the app layer with `--live`:
+
+```shell
+% API_HOST=localhoist scan-env --live -v
+Missing in live context
+
+JWT:
+	stories/pois.stories.js (has default)
+MAPBOX_ACCESS_TOKEN:
+	stories/pois.stories.js (has default)
+
+3 env vars found in 1 file
+API_HOST            stories/pois.stories.js
+JWT                 stories/pois.stories.js
+MAPBOX_ACCESS_TOKEN stories/pois.stories.js
 ```
 
 ### `<ignore scan-env>`

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const NODE_REGEX = [
   // env['key'] or env.prop with `||` default support
   /env(\[["|'](?<key>\w*)["|']\]|\.(?<prop>\w*))(?<def>\s*\|\|)?/g,
   // destructuring such as { dict } = process.env
-  /{(?<dict>.*)}\s*=\s*process.env/g,
+  /{(?<dict>(?:[^}]+)*)}\s*=\s*process.env/g,
 ]
 
 function jsParser(text) {
@@ -46,7 +46,7 @@ function jsParser(text) {
       const defaults = new Set()
       const { key, prop, def, dict } = match.groups
       if (dict) { // destructuring case
-        dict.split(',').forEach((v) => {
+        dict.split(',').map((v) => v.trim()).filter((v) => v).forEach((v) => {
           const [k, d] = v.split('=').map((s) => s.trim())
           const _var = k.split(':')[0].trim()
           vars.add(_var)

--- a/index.js
+++ b/index.js
@@ -167,16 +167,20 @@ function formatWarning({ missing, allVars }) {
 }
 
 function formatAll({ needed, verbose }) {
-  const counts = { vars: 0, files: 0 }
+  const uniques = { vars: [], files: [] }
   let maxWidth = 0
   const _needed = Object.entries(needed).reduce((acc, [k, fps]) => {
     acc[k] = Array.from(fps)
-    counts.vars += 1
-    counts.files += fps.size
+    uniques.vars.push(k)
+    uniques.files = uniques.files.concat(acc[k])
     maxWidth = Math.max(maxWidth, k.length)
     return acc
   }, {})
-  let s = `${chalk.blue(`${chalk.bold(counts.vars)} env vars found in ${chalk.bold(counts.files)} files`)}`
+  uniques.vars = new Set(uniques.vars)
+  uniques.files = new Set(uniques.files)
+  const sVars = `${chalk.bold(uniques.vars.size)} env var${uniques.vars.size > 1 ? 's' : ''}`
+  const sFiles = `${chalk.bold(uniques.files.size)} file${uniques.files.size > 1 ? 's' : ''}`
+  let s = chalk.blue(`${sVars} found in ${sFiles}`)
   if (verbose) {
     s += `\n`
     Object.entries(_needed).forEach(([k, fps]) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eqworks/scan-env",
-  "version": "0.3.0",
+  "version": "0.4.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eqworks/scan-env",
-      "version": "0.3.0",
+      "version": "0.4.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/scan-env",
-  "version": "0.3.0",
+  "version": "0.4.0-alpha.0",
   "description": "Utility to scan environment variable usage in a git repository.",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
to support projects that do not have serverless configs, for example:

```shell
(poi-manage) % scan-env --live
Missing in live context

API_HOST:
	stories/pois.stories.js (has default)
JWT:
	stories/pois.stories.js (has default)
MAPBOX_ACCESS_TOKEN:
	stories/pois.stories.js (has default)

(poi-manage) % API_HOST=localhoist scan-env --live
Missing in live context

JWT:
	stories/pois.stories.js (has default)
MAPBOX_ACCESS_TOKEN:
	stories/pois.stories.js (has default)
```

```shelll
(ml-ui) % scan-env --live
Missing in live context

API_HOST:
	src/index.js (has default)
	stories/wl-cu-selector.js (has default)
```